### PR TITLE
Issue 1 - function #arrayindex returns null instead of expected value

### DIFF
--- a/ExtArrays.php
+++ b/ExtArrays.php
@@ -633,7 +633,7 @@ class ExtArrays {
 
 		if ( $store->arrayExists( $arrayId ) ) {
 			$array = $store->getArray( $arrayId );
-			$array = self::array_unique( $array );
+			$array = array_values( self::array_unique( $array ) );
 			$store->setArray( $arrayId, $array );
 		}
 		return '';


### PR DESCRIPTION
This PR is related to the issue #1.

This PR contains:

- function `pf_arrayunique()` updated
- `array_values()` added to handle indexes in new array after applying `array_unique`